### PR TITLE
Fix topology machine label when second or third octet need display

### DIFF
--- a/src/lab-generator/make_draw_model.js
+++ b/src/lab-generator/make_draw_model.js
@@ -71,9 +71,9 @@ function get_eth_ip_difference(network, ip) {
 	if (net_split_i.length != ip_split_i.length) return 0;
 	for (let i in net_split_i) {
 		if (net_split_i[i] != ip_split_i[i]) {
-			if (i == 3) return ip_split_i[i];
-			if (i == 2) return ip_split_i[i] + "." + ip_split_i[i + 1];
-			if (i == 1) return ip_split_i[i] + "." + ip_split_i[i + 1] + "." + ip_split_i[i + 2];
+			if (i == 3) return ip_split_i[3];
+			if (i == 2) return ip_split_i[2] + "." + ip_split_i[3];
+			if (i == 1) return ip_split_i[1] + "." + ip_split_i[2] + "." + ip_split_i[3];
 			if (i == 0) return ip_split;
 		}
 	}


### PR DESCRIPTION
. Samples display IPs fix: 10.50.0.1/8, 172.16.54.4/16

When machine IP is 10.53.53.53/8 label show  53.undefined.undefined