### PR TITLE
add-topology-options

### DIFF
--- a/index.html
+++ b/index.html
@@ -601,7 +601,7 @@
 
 				<div id="controls" style="border: 1px solid lightgray; width: 100%; margin-top: 1em;">
 					<div class="row" style="margin: 0 !important;">
-						<div class="col-md-offset-4 col-md-2">
+						<div class="col-md-offset-3 col-md-2">
 							<h3 class="margin-bottom: 5px;">Edges smoothness</h3>
 
 							<div class="form-group">
@@ -634,7 +634,7 @@
 							<div class="form-group">
 								<input class="form-check-input" type="checkbox" value="" id="physicsEnabled"
 									onclick="setNetworkOptions()">
-								<label class="form-check-label" for="smoothEnabled">
+								<label class="form-check-label" for="physicsEnabled">
 									Enabled
 								</label>
 							</div>
@@ -647,10 +647,34 @@
 									value='-1200' id='physicsGravitationalConstantValue' readonly='true'>
 							</div>
 						</div>
+						<div class="col-md-2">
+							<h3 class="margin-bottom: 5px;">Miscellaneous</h3>
+
+							<div class="form-group">
+							  <input class="form-check-input" type="checkbox" value="" id="ifNameAt">
+							  <label class="form-check-label" for="ifNameAt">
+								Replace interface name with "@"
+							  </label>
+							</div>
+
+							<div class="form-group">
+							  <input class="form-check-input" type="checkbox" value="" id="ifOspfCost">
+							  <label class="form-check-label" for="ifOspfCost">
+								Show OSPF interface cost
+							  </label>
+							</div>
+
+							<div class="form-group">
+							  <input class="form-check-input" type="checkbox" value="" id="routingLabel">
+							  <label class="form-check-label" for="routingLabel">
+								Show OSPF/RIP/BGP label on router
+							  </label>
+							</div>
+						  </div>
 					</div>
 
 					<div class="row" style="margin: 0 !important; margin-top: 10px;">
-						<div class="col-md-offset-4 col-md-4">
+						<div class="col-md-offset-3 col-md-6">
 							<div class="form-group">
 								<button class="btn btn-danger btn-block" data-ng-click="makeGraph(netkit)">Reset</button>
 							</div>


### PR DESCRIPTION
Added a new group in Topology controls: "Miscellaneous".
This section contains three checkboxes that will take effect on graph reset:

- Replace interface name with "@"
- Show OSPF interface cost
- Show OSPF/RIP/BGP label on router

![Screenshot_2](https://github.com/KatharaFramework/Netkit-Lab-Generator/assets/81924427/606077d3-4bb2-4801-84db-d9ce6a7729a9)